### PR TITLE
Corresponding to variable dimension

### DIFF
--- a/src/sprm/sprm.py
+++ b/src/sprm/sprm.py
@@ -438,7 +438,11 @@ class sprm(_BaseComposition,BaseEstimator,TransformerMixin,RegressorMixin):
         if self.verbose:
             print("Final Model: Variables retained for " + str(self.n_components) + " latent variables: \n" 
                  + str(res_snipls.colret_) + "\n")
-        b_rescaled = np.reshape(yrc.col_sca/Xrc.col_sca,(5,1))*b
+
+        # Is not "5" a constant of example?
+        # b_rescaled = np.reshape(yrc.col_sca/Xrc.col_sca,(5,1))*b
+        # Corresponding to variable dimension (X-dimension : p)
+        b_rescaled = np.reshape(yrc.col_sca/Xrc.col_sca,(p,1))*b
         if(self.centring == "mean"):
             intercept = np.mean(y - np.matmul(X,b_rescaled))
         else:


### PR DESCRIPTION
When the X-dimension is set to other than 5, the following error occurred.
```
Traceback (most recent call last):
  File "main.py", line 18, in <module>
    sprm_.fit(X[:100], Y[:100])
  File "/usr/local/lib/python3.6/site-packages/sprm/sprm.py", line 441, in fit
    b_rescaled = np.reshape(yrc.col_sca/Xrc.col_sca,(5,1))*b
  File "/usr/local/lib/python3.6/site-packages/numpy/core/fromnumeric.py", line 257, in reshape
    return _wrapfunc(a, 'reshape', newshape, order=order)
  File "/usr/local/lib/python3.6/site-packages/numpy/core/fromnumeric.py", line 52, in _wrapfunc
    return getattr(obj, method)(*args, **kwds)
ValueError: cannot reshape array of size 15 into shape (5,1)
```
Is not it because the dimension number of b_rescaled's rehsape is a constant of 5?
I corrected it to the appropriate dimension number p